### PR TITLE
Renamed tags to tag in the Movie table to prevent a naming collision …

### DIFF
--- a/server/db/models/movie.js
+++ b/server/db/models/movie.js
@@ -19,7 +19,7 @@ const Movie = db.define('movies', {
   cast: {
     type: Sequelize.ARRAY(Sequelize.STRING)
   },
-  tags: {
+  tag: {
     type: Sequelize.ARRAY(Sequelize.STRING)
   },
   summary: {


### PR DESCRIPTION
Had to rename the "tags" member of the Movie table to "tag".  This cured this crash error: 
Error: Naming collision between attribute 'tags' and association 'tags' on model movies. 